### PR TITLE
Feature/cast and creatives - split screens and handle large lists

### DIFF
--- a/src/components/EventDetailsComponents/commonControls/MultiColumnRoleNameList.tsx
+++ b/src/components/EventDetailsComponents/commonControls/MultiColumnRoleNameList.tsx
@@ -1,0 +1,51 @@
+import { FlatList, View, StyleSheet, LogBox } from "react-native";
+import RohText from "@components/RohText";
+import { scaleSize } from "@utils/scaleSize";
+import React, { useEffect } from 'react';
+
+type MultiColumnRoleNameListProps = {
+    data: Array<{role: string, name: string}>,
+    numColumns: number
+};
+
+const MultiColumnRoleNameList: React.FC<MultiColumnRoleNameListProps> = ({
+    data,
+    numColumns
+  }) => {
+    useEffect(() => {
+      LogBox.ignoreLogs(['VirtualizedLists should never be nested']);
+    }, [])
+    return (
+      <FlatList
+        numColumns={numColumns}
+        style={{ flex: 1 }}
+        data={data}
+        keyExtractor={item => item.role}
+        renderItem = {({ item }) => (
+        <View style={styles.elementContainer}>
+          <RohText style={styles.role}>{item.role}</RohText>
+          <RohText style={styles.name}>{item.name}</RohText>
+        </View>
+        )}
+      />
+      );
+    };
+
+    const styles = StyleSheet.create({
+    role: {
+        fontSize: scaleSize(20),
+        color: '#7E91B4',
+        textTransform: 'uppercase',
+      },
+      name: {
+        color: 'white',
+        fontSize: scaleSize(20),
+      },
+      elementContainer: {
+        marginBottom: scaleSize(32),
+        flex: 1,
+        maxWidth: `${1/3 * 100}%`
+      },
+    });
+
+    export default MultiColumnRoleNameList;

--- a/src/components/EventDetailsComponents/commonControls/MultiColumnRoleNameList.tsx
+++ b/src/components/EventDetailsComponents/commonControls/MultiColumnRoleNameList.tsx
@@ -14,6 +14,7 @@ type TMultiColumnRoleNameListProps = {
 export type TMultiColumnRoleNameListRef = {
   scrollToEnd?: () => void;
   scrollToTop?: () => void;
+  setHasMore?: () => void;
 };
 
 const MultiColumnRoleNameList = React.forwardRef<any,TMultiColumnRoleNameListProps> (
@@ -57,7 +58,7 @@ const MultiColumnRoleNameList = React.forwardRef<any,TMultiColumnRoleNameListPro
         keyExtractor={item => item.role}
         renderItem = {({ item }) => (
           <View
-            style={styles.elementContainer}
+            style={[styles.elementContainer, {maxWidth: `${1/numColumns * 100}%`}]}
             onLayout={(event: LayoutChangeEvent) => setItemHeight(event.nativeEvent.layout.height)}>
             <RohText style={styles.role}>{item.role}</RohText>
             <RohText style={styles.name}>{item.name}</RohText>
@@ -80,7 +81,6 @@ const MultiColumnRoleNameList = React.forwardRef<any,TMultiColumnRoleNameListPro
       elementContainer: {
         marginBottom: scaleSize(32),
         flex: 1,
-        maxWidth: `${1/3 * 100}%`
       },
       list: {
         flex: 1

--- a/src/components/EventDetailsComponents/commonControls/MultiColumnRoleNameList.tsx
+++ b/src/components/EventDetailsComponents/commonControls/MultiColumnRoleNameList.tsx
@@ -9,12 +9,12 @@ type TMultiColumnRoleNameListProps = {
     numColumns: number,
     setItemHeight(height: number): void
     setContainerHeight(height: number): void
+    setReachedEnd: (distanceFromEnd: number) => void;
 };
 
 export type TMultiColumnRoleNameListRef = {
   scrollToEnd?: () => void;
   scrollToTop?: () => void;
-  setHasMore?: () => void;
 };
 
 const MultiColumnRoleNameList = React.forwardRef<any,TMultiColumnRoleNameListProps> (
@@ -23,7 +23,8 @@ const MultiColumnRoleNameList = React.forwardRef<any,TMultiColumnRoleNameListPro
       data,
       numColumns,
       setItemHeight,
-      setContainerHeight
+      setContainerHeight,
+      setReachedEnd,
     } = props;
 
     const flatlistRef = useRef<FlatList>(null);
@@ -51,7 +52,12 @@ const MultiColumnRoleNameList = React.forwardRef<any,TMultiColumnRoleNameListPro
     return (
       <FlatList
         ref={flatlistRef}
+        showsVerticalScrollIndicator={false}
         onLayout={(event: LayoutChangeEvent) => setContainerHeight(event.nativeEvent.layout.height)}
+        onEndReached={({distanceFromEnd}) => {
+          return setReachedEnd(distanceFromEnd);
+        }}
+        onEndReachedThreshold={0.1}
         numColumns={numColumns}
         style={styles.list}
         data={data}

--- a/src/components/EventDetailsComponents/components/Cast.tsx
+++ b/src/components/EventDetailsComponents/components/Cast.tsx
@@ -31,6 +31,7 @@ const Cast: React.FC<CastProps> = ({
 }) => {
   const [active, toggleActive] = useState(false);
   const [numColumns, setNumColumns] = useState(1);
+  const [shouldShowHasMore, setShouldShowHasMore] = useState(true);
   const columnContainerRef = useRef<TMultiColumnRoleNameListRef>(null);
   const accumulatedHeight = useRef(0);
   const containerHeight = useRef(0);
@@ -87,17 +88,21 @@ const Cast: React.FC<CastProps> = ({
     setNumColumns(Math.min(numColumns + 1, MAX_NUM_COLUMNS));
   }
 
+  const updateReachedEnd = (distanceFromEnd: number) => {
+    setShouldShowHasMore(false);
+  }
+
   return (
     <TouchableHighlightWrapper
       onPress={() => {
-        toggleActive(!active);
-        scroll();
+          toggleActive(!active);
+          scroll();
       }}
       >
       <View style={styles.generalContainer}>
         <View style={styles.wrapper}>
           <RohText style={styles.title}>Cast</RohText>
-          <View style={active ? styles.highlightActive : styles.highlightHidden} />
+          <View style={active && shouldShowHasMore ? styles.highlightActive : styles.highlightHidden} />
             <View style={styles.castContainer}>
               <View style={styles.columnContainer}>
                 <MultiColumnRoleNameList
@@ -107,7 +112,9 @@ const Cast: React.FC<CastProps> = ({
                   ref={columnContainerRef}
                   setItemHeight={height => accumulateHeight(height)}
                   setContainerHeight={height => setContainerHeight(height)}
+                  setReachedEnd={(distanceFromEnd) => updateReachedEnd(distanceFromEnd)}
                 />
+                {shouldShowHasMore && <RohText style={styles.hasMore}>Press select for more...</RohText>}
               </View>
             </View>
           </View>
@@ -173,6 +180,14 @@ const styles = StyleSheet.create({
   columnContainer: {
     flex: 1,
   },
+  hasMore: {
+    color: Colors.defaultTextColor,
+    opacity: 0.8,
+    position: 'absolute',
+    bottom: scaleSize(10),
+    alignSelf: 'center',
+    backgroundColor: Colors.backgroundColorTransparent
+  }
 });
 
 export default Cast;

--- a/src/components/EventDetailsComponents/components/Cast.tsx
+++ b/src/components/EventDetailsComponents/components/Cast.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   View,
   StyleSheet,
   Dimensions,
   TouchableHighlight,
   ScrollView,
+  FlatList,
+  LogBox,
 } from 'react-native';
 import { scaleSize } from '@utils/scaleSize';
 import {
@@ -16,6 +18,7 @@ import RohText from '@components/RohText';
 import GoDown from '../commonControls/GoDown';
 import get from 'lodash.get';
 import TouchableHighlightWrapper from '@components/TouchableHighlightWrapper';
+import MultiColumnRoleNameList from '../commonControls/MultiColumnRoleNameList';
 
 type CastProps = {
   event: TEventContainer;
@@ -49,6 +52,8 @@ const Cast: React.FC<CastProps> = ({
     },
     {},
   );
+  let data: Array<{role: string, name: string}> = [];
+  Object.entries(listOfEvalableCasts).map(([role, name]) => data.push({ role, name }));
   return (
     <TouchableHighlightWrapper>
       <View style={styles.generalContainer}>
@@ -56,15 +61,7 @@ const Cast: React.FC<CastProps> = ({
           <RohText style={styles.title}>Cast</RohText>
           <View style={styles.castCreativesContainer}>
             <View style={styles.columnContainer}>
-              <RohText style={styles.columnTtitle}>Cast</RohText>
-              <ScrollView>
-                {Object.entries(listOfEvalableCasts).map(([role, name]) => (
-                  <View style={styles.elementContainer} key={role}>
-                    <RohText style={styles.role}>{role}</RohText>
-                    <RohText style={styles.name}>{name}</RohText>
-                  </View>
-                ))}
-              </ScrollView>
+              <MultiColumnRoleNameList numColumns={3} data={data} />
             </View>
           </View>
         </View>
@@ -115,18 +112,6 @@ const styles = StyleSheet.create({
     fontSize: scaleSize(26),
     textTransform: 'uppercase',
     marginBottom: scaleSize(20),
-  },
-  elementContainer: {
-    marginBottom: scaleSize(32),
-  },
-  role: {
-    fontSize: scaleSize(20),
-    color: '#7E91B4',
-    textTransform: 'uppercase',
-  },
-  name: {
-    color: 'white',
-    fontSize: scaleSize(20),
   },
 });
 

--- a/src/components/EventDetailsComponents/components/Cast.tsx
+++ b/src/components/EventDetailsComponents/components/Cast.tsx
@@ -1,24 +1,20 @@
-import React, { useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import {
   View,
   StyleSheet,
   Dimensions,
-  TouchableHighlight,
-  ScrollView,
-  FlatList,
-  LogBox,
 } from 'react-native';
 import { scaleSize } from '@utils/scaleSize';
 import {
   TEventContainer,
   TVSEventDetailsCast,
-  TVSEventDetailsCreative,
 } from '@services/types/models';
 import RohText from '@components/RohText';
 import GoDown from '../commonControls/GoDown';
 import get from 'lodash.get';
 import TouchableHighlightWrapper from '@components/TouchableHighlightWrapper';
-import MultiColumnRoleNameList from '../commonControls/MultiColumnRoleNameList';
+import MultiColumnRoleNameList, { TMultiColumnRoleNameListRef } from '../commonControls/MultiColumnRoleNameList';
+import { Colors } from '@themes/Styleguide';
 
 type CastProps = {
   event: TEventContainer;
@@ -26,11 +22,19 @@ type CastProps = {
   scrollToMe: () => void;
 };
 
+const MAX_NUM_COLUMNS = 3;
+
 const Cast: React.FC<CastProps> = ({
   event,
   nextScreenText,
   scrollToMe,
 }) => {
+  const [active, toggleActive] = useState(false);
+  const [numColumns, setNumColumns] = useState(1);
+  const columnContainerRef = useRef<TMultiColumnRoleNameListRef>(null);
+  const accumulatedHeight = useRef(0);
+  const containerHeight = useRef(0);
+
   const castList: Array<TVSEventDetailsCast> = get(
     event.data,
     ['vs_event_details', 'cast'],
@@ -54,17 +58,59 @@ const Cast: React.FC<CastProps> = ({
   );
   let data: Array<{role: string, name: string}> = [];
   Object.entries(listOfEvalableCasts).map(([role, name]) => data.push({ role, name }));
+
+  const scroll = () => {
+    if(!active) {
+      if(columnContainerRef.current) {
+        columnContainerRef.current.scrollToEnd && columnContainerRef.current.scrollToEnd();
+      }
+    } else {
+      if(columnContainerRef.current) {
+        columnContainerRef.current.scrollToTop && columnContainerRef.current.scrollToTop();
+      }
+    }
+  }
+
+  const accumulateHeight = (height: number) => {
+    accumulatedHeight.current += height;
+    if(containerHeight.current > 0 && accumulatedHeight.current > containerHeight.current) {
+      incrementColumns();
+      accumulatedHeight.current = 0;
+    }
+  }
+
+  const setContainerHeight = (height: number) => {
+    if(containerHeight.current == 0) containerHeight.current = height
+  }
+  
+  const incrementColumns = () => {
+    setNumColumns(Math.min(numColumns + 1, MAX_NUM_COLUMNS));
+  }
+
   return (
-    <TouchableHighlightWrapper>
+    <TouchableHighlightWrapper
+      onPress={() => {
+        toggleActive(!active);
+        scroll();
+      }}
+      >
       <View style={styles.generalContainer}>
         <View style={styles.wrapper}>
           <RohText style={styles.title}>Cast</RohText>
-          <View style={styles.castCreativesContainer}>
-            <View style={styles.columnContainer}>
-              <MultiColumnRoleNameList numColumns={3} data={data} />
+          <View style={active ? styles.highlightActive : styles.highlightHidden} />
+            <View style={styles.castContainer}>
+              <View style={styles.columnContainer}>
+                <MultiColumnRoleNameList
+                  numColumns={numColumns}
+                  key={numColumns}
+                  data={data}
+                  ref={columnContainerRef}
+                  setItemHeight={height => accumulateHeight(height)}
+                  setContainerHeight={height => setContainerHeight(height)}
+                />
+              </View>
             </View>
           </View>
-        </View>
         <View style={styles.downContainer}>
           <GoDown text={nextScreenText} scrollToMe={scrollToMe} />
         </View>
@@ -94,24 +140,38 @@ const styles = StyleSheet.create({
   },
   title: {
     flex: 1,
-    color: 'white',
+    color: Colors.title,
     fontSize: scaleSize(72),
     textTransform: 'uppercase',
   },
-  castCreativesContainer: {
+  castContainer: {
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  columnContainer: {
-    flex: 1,
-  },
-  columnTtitle: {
-    color: 'white',
+  columnTitle: {
+    color: Colors.title,
     fontSize: scaleSize(26),
     textTransform: 'uppercase',
     marginBottom: scaleSize(20),
+  },
+  highlightActive: {
+    position: 'absolute',
+    left: scaleSize(720),
+    width: scaleSize(960),
+    height: scaleSize(900),
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderColor: Colors.defaultBlue,
+    borderWidth: 5
+  },
+  highlightHidden: {
+    display: 'none'
+  },
+  columnContainer: {
+    flex: 1,
   },
 });
 

--- a/src/components/EventDetailsComponents/components/Cast.tsx
+++ b/src/components/EventDetailsComponents/components/Cast.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import {
+  View,
+  StyleSheet,
+  Dimensions,
+  TouchableHighlight,
+  ScrollView,
+} from 'react-native';
+import { scaleSize } from '@utils/scaleSize';
+import {
+  TEventContainer,
+  TVSEventDetailsCast,
+  TVSEventDetailsCreative,
+} from '@services/types/models';
+import RohText from '@components/RohText';
+import GoDown from '../commonControls/GoDown';
+import get from 'lodash.get';
+import TouchableHighlightWrapper from '@components/TouchableHighlightWrapper';
+
+type CastProps = {
+  event: TEventContainer;
+  nextScreenText: string;
+  scrollToMe: () => void;
+};
+
+const Cast: React.FC<CastProps> = ({
+  event,
+  nextScreenText,
+  scrollToMe,
+}) => {
+  const castList: Array<TVSEventDetailsCast> = get(
+    event.data,
+    ['vs_event_details', 'cast'],
+    [],
+  );
+  const listOfEvalableCasts = castList.reduce<{ [key: string]: string }>(
+    (acc, cast) => {
+      const role = get(cast, ['attributes', 'role'], '');
+      const name = get(cast, ['attributes', 'name'], '');
+      if (!name) {
+        return acc;
+      }
+      if (role && role in acc) {
+        acc[role] += `, ${name}`;
+      } else {
+        acc[role] = name;
+      }
+      return acc;
+    },
+    {},
+  );
+  return (
+    <TouchableHighlightWrapper>
+      <View style={styles.generalContainer}>
+        <View style={styles.wrapper}>
+          <RohText style={styles.title}>Cast</RohText>
+          <View style={styles.castCreativesContainer}>
+            <View style={styles.columnContainer}>
+              <RohText style={styles.columnTtitle}>Cast</RohText>
+              <ScrollView>
+                {Object.entries(listOfEvalableCasts).map(([role, name]) => (
+                  <View style={styles.elementContainer} key={role}>
+                    <RohText style={styles.role}>{role}</RohText>
+                    <RohText style={styles.name}>{name}</RohText>
+                  </View>
+                ))}
+              </ScrollView>
+            </View>
+          </View>
+        </View>
+        <View style={styles.downContainer}>
+          <GoDown text={nextScreenText} scrollToMe={scrollToMe} />
+        </View>
+      </View>
+    </TouchableHighlightWrapper>
+  );
+};
+
+const styles = StyleSheet.create({
+  generalContainer: {
+    height: Dimensions.get('window').height,
+    paddingRight: scaleSize(200),
+  },
+  wrapper: {
+    marginTop: scaleSize(110),
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  downContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    height: scaleSize(50),
+    marginBottom: scaleSize(60),
+  },
+  title: {
+    flex: 1,
+    color: 'white',
+    fontSize: scaleSize(72),
+    textTransform: 'uppercase',
+  },
+  castCreativesContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  columnContainer: {
+    flex: 1,
+  },
+  columnTtitle: {
+    color: 'white',
+    fontSize: scaleSize(26),
+    textTransform: 'uppercase',
+    marginBottom: scaleSize(20),
+  },
+  elementContainer: {
+    marginBottom: scaleSize(32),
+  },
+  role: {
+    fontSize: scaleSize(20),
+    color: '#7E91B4',
+    textTransform: 'uppercase',
+  },
+  name: {
+    color: 'white',
+    fontSize: scaleSize(20),
+  },
+});
+
+export default Cast;

--- a/src/components/EventDetailsComponents/components/Creatives.tsx
+++ b/src/components/EventDetailsComponents/components/Creatives.tsx
@@ -9,7 +9,6 @@ import {
 import { scaleSize } from '@utils/scaleSize';
 import {
   TEventContainer,
-  TVSEventDetailsCast,
   TVSEventDetailsCreative,
 } from '@services/types/models';
 import RohText from '@components/RohText';
@@ -17,38 +16,17 @@ import GoDown from '../commonControls/GoDown';
 import get from 'lodash.get';
 import TouchableHighlightWrapper from '@components/TouchableHighlightWrapper';
 
-type CastAndCreativesProps = {
+type CreativesProps = {
   event: TEventContainer;
   nextScreenText: string;
   scrollToMe: () => void;
 };
 
-const CastAndCreatives: React.FC<CastAndCreativesProps> = ({
+const Creatives: React.FC<CreativesProps> = ({
   event,
   nextScreenText,
   scrollToMe,
 }) => {
-  const castList: Array<TVSEventDetailsCast> = get(
-    event.data,
-    ['vs_event_details', 'cast'],
-    [],
-  );
-  const listOfEvalableCasts = castList.reduce<{ [key: string]: string }>(
-    (acc, cast) => {
-      const role = get(cast, ['attributes', 'role'], '');
-      const name = get(cast, ['attributes', 'name'], '');
-      if (!name) {
-        return acc;
-      }
-      if (role && role in acc) {
-        acc[role] += `, ${name}`;
-      } else {
-        acc[role] = name;
-      }
-      return acc;
-    },
-    {},
-  );
   const creativesList: Array<TVSEventDetailsCreative> = get(
     event.data,
     ['vs_event_details', 'creatives'],
@@ -73,19 +51,8 @@ const CastAndCreatives: React.FC<CastAndCreativesProps> = ({
     <TouchableHighlightWrapper>
       <View style={styles.generalContainer}>
         <View style={styles.wrapper}>
-          <RohText style={styles.title}>Cast {'\n'}& Creatives</RohText>
+          <RohText style={styles.title}>Creatives</RohText>
           <View style={styles.castCreativesContainer}>
-            <View style={styles.columnContainer}>
-              <RohText style={styles.columnTtitle}>Cast</RohText>
-              <ScrollView>
-                {Object.entries(listOfEvalableCasts).map(([role, name]) => (
-                  <View style={styles.elementContainer} key={role}>
-                    <RohText style={styles.role}>{role}</RohText>
-                    <RohText style={styles.name}>{name}</RohText>
-                  </View>
-                ))}
-              </ScrollView>
-            </View>
             <View style={styles.columnContainer}>
               <RohText style={styles.columnTtitle}>Creatives</RohText>
               <ScrollView>
@@ -161,4 +128,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default CastAndCreatives;
+export default Creatives;

--- a/src/components/EventDetailsComponents/components/Creatives.tsx
+++ b/src/components/EventDetailsComponents/components/Creatives.tsx
@@ -1,11 +1,8 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import {
   View,
   StyleSheet,
   Dimensions,
-  TouchableHighlight,
-  ScrollView,
-  FlatList,
 } from 'react-native';
 import { scaleSize } from '@utils/scaleSize';
 import {
@@ -16,7 +13,8 @@ import RohText from '@components/RohText';
 import GoDown from '../commonControls/GoDown';
 import get from 'lodash.get';
 import TouchableHighlightWrapper from '@components/TouchableHighlightWrapper';
-import MultiColumnRoleNameList from '../commonControls/MultiColumnRoleNameList';
+import MultiColumnRoleNameList, { TMultiColumnRoleNameListRef } from '../commonControls/MultiColumnRoleNameList';
+import { Colors } from '@themes/Styleguide';
 
 type CreativesProps = {
   event: TEventContainer;
@@ -24,16 +22,25 @@ type CreativesProps = {
   scrollToMe: () => void;
 };
 
+const MAX_NUM_COLUMNS = 3;
+
 const Creatives: React.FC<CreativesProps> = ({
   event,
   nextScreenText,
   scrollToMe,
 }) => {
+  const [active, toggleActive] = useState(false);
+  const [numColumns, setNumColumns] = useState(1);
+  const columnContainerRef = useRef<TMultiColumnRoleNameListRef>(null);
+  const accumulatedHeight = useRef(0);
+  const containerHeight = useRef(0);
+  
   const creativesList: Array<TVSEventDetailsCreative> = get(
     event.data,
     ['vs_event_details', 'creatives'],
     [],
   );
+
   const listOfEvalableCreatives = creativesList.reduce<{
     [key: string]: string;
   }>((acc, cast) => {
@@ -50,19 +57,62 @@ const Creatives: React.FC<CreativesProps> = ({
     return acc;
   }, {});
   let data: Array<{role: string, name: string}> = [];
-  Object.entries(listOfEvalableCreatives).map(([role, name]) => data.push({ role, name }));
+  Object.entries(listOfEvalableCreatives).map(([role, name]) => {
+    data.push({ role, name });
+  });
+
+  const scroll = () => {
+    if(!active) {
+      if(columnContainerRef.current) {
+        columnContainerRef.current.scrollToEnd && columnContainerRef.current.scrollToEnd();
+      }
+    } else {
+      if(columnContainerRef.current) {
+        columnContainerRef.current.scrollToTop && columnContainerRef.current.scrollToTop();
+      }
+    }
+  }
+
+  const accumulateHeight = (height: number) => {
+    accumulatedHeight.current += height;
+    if(containerHeight.current > 0 && accumulatedHeight.current > containerHeight.current) {
+      incrementColumns();
+      accumulatedHeight.current = 0;
+    }
+  }
+
+  const setContainerHeight = (height: number) => {
+    if(containerHeight.current == 0) containerHeight.current = height
+  }
+  
+  const incrementColumns = () => {
+    setNumColumns(Math.min(numColumns + 1, MAX_NUM_COLUMNS));
+  }
 
   return (
-    <TouchableHighlightWrapper>
+    <TouchableHighlightWrapper
+      onPress={() => {
+        toggleActive(!active);
+        scroll();
+      }}
+      >
       <View style={styles.generalContainer}>
         <View style={styles.wrapper}>
-        <RohText style={styles.title}>Creatives</RohText>
-          <View style={styles.castCreativesContainer}>
-            <View style={styles.columnContainer}>
-              <MultiColumnRoleNameList numColumns={3} data={data} />
+          <RohText style={styles.title}>Creatives</RohText>
+          <View style={active ? styles.highlightActive : styles.highlightHidden} />
+            <View style={styles.creativesContainer}>
+              <View style={styles.columnContainer}>
+                <MultiColumnRoleNameList
+                  numColumns={numColumns}
+                  key={numColumns}
+                  data={data}
+                  ref={columnContainerRef}
+                  setItemHeight={height => accumulateHeight(height)}
+                  setContainerHeight={height => setContainerHeight(height)}
+                />
+              </View>
             </View>
           </View>
-        </View>
         <View style={styles.downContainer}>
           <GoDown text={nextScreenText} scrollToMe={scrollToMe} />
         </View>
@@ -92,24 +142,38 @@ const styles = StyleSheet.create({
   },
   title: {
     flex: 1,
-    color: 'white',
+    color: Colors.title,
     fontSize: scaleSize(72),
     textTransform: 'uppercase',
   },
-  castCreativesContainer: {
+  creativesContainer: {
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  columnContainer: {
-    flex: 1,
-  },
   columnTtitle: {
-    color: 'white',
+    color: Colors.title,
     fontSize: scaleSize(26),
     textTransform: 'uppercase',
     marginBottom: scaleSize(20),
+  },
+  highlightActive: {
+    position: 'absolute',
+    left: scaleSize(720),
+    width: scaleSize(960),
+    height: scaleSize(900),
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderColor: Colors.defaultBlue,
+    borderWidth: 5
+  },
+  highlightHidden: {
+    display: 'none'
+  },
+  columnContainer: {
+    flex: 1,
   },
 });
 

--- a/src/components/EventDetailsComponents/components/Creatives.tsx
+++ b/src/components/EventDetailsComponents/components/Creatives.tsx
@@ -152,7 +152,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  columnTtitle: {
+  columnTitle: {
     color: Colors.title,
     fontSize: scaleSize(26),
     textTransform: 'uppercase',

--- a/src/components/EventDetailsComponents/components/Creatives.tsx
+++ b/src/components/EventDetailsComponents/components/Creatives.tsx
@@ -5,6 +5,7 @@ import {
   Dimensions,
   TouchableHighlight,
   ScrollView,
+  FlatList,
 } from 'react-native';
 import { scaleSize } from '@utils/scaleSize';
 import {
@@ -15,6 +16,7 @@ import RohText from '@components/RohText';
 import GoDown from '../commonControls/GoDown';
 import get from 'lodash.get';
 import TouchableHighlightWrapper from '@components/TouchableHighlightWrapper';
+import MultiColumnRoleNameList from '../commonControls/MultiColumnRoleNameList';
 
 type CreativesProps = {
   event: TEventContainer;
@@ -47,22 +49,17 @@ const Creatives: React.FC<CreativesProps> = ({
     }
     return acc;
   }, {});
+  let data: Array<{role: string, name: string}> = [];
+  Object.entries(listOfEvalableCreatives).map(([role, name]) => data.push({ role, name }));
+
   return (
     <TouchableHighlightWrapper>
       <View style={styles.generalContainer}>
         <View style={styles.wrapper}>
-          <RohText style={styles.title}>Creatives</RohText>
+        <RohText style={styles.title}>Creatives</RohText>
           <View style={styles.castCreativesContainer}>
             <View style={styles.columnContainer}>
-              <RohText style={styles.columnTtitle}>Creatives</RohText>
-              <ScrollView>
-                {Object.entries(listOfEvalableCreatives).map(([role, name]) => (
-                  <View style={styles.elementContainer} key={role}>
-                    <RohText style={styles.role}>{role}</RohText>
-                    <RohText style={styles.name}>{name}</RohText>
-                  </View>
-                ))}
-              </ScrollView>
+              <MultiColumnRoleNameList numColumns={3} data={data} />
             </View>
           </View>
         </View>
@@ -113,18 +110,6 @@ const styles = StyleSheet.create({
     fontSize: scaleSize(26),
     textTransform: 'uppercase',
     marginBottom: scaleSize(20),
-  },
-  elementContainer: {
-    marginBottom: scaleSize(32),
-  },
-  role: {
-    fontSize: scaleSize(20),
-    color: '#7E91B4',
-    textTransform: 'uppercase',
-  },
-  name: {
-    color: 'white',
-    fontSize: scaleSize(20),
   },
 });
 

--- a/src/components/EventDetailsComponents/components/Creatives.tsx
+++ b/src/components/EventDetailsComponents/components/Creatives.tsx
@@ -31,6 +31,7 @@ const Creatives: React.FC<CreativesProps> = ({
 }) => {
   const [active, toggleActive] = useState(false);
   const [numColumns, setNumColumns] = useState(1);
+  const [shouldShowHasMore, setShouldShowHasMore] = useState(true);
   const columnContainerRef = useRef<TMultiColumnRoleNameListRef>(null);
   const accumulatedHeight = useRef(0);
   const containerHeight = useRef(0);
@@ -89,6 +90,10 @@ const Creatives: React.FC<CreativesProps> = ({
     setNumColumns(Math.min(numColumns + 1, MAX_NUM_COLUMNS));
   }
 
+  const updateReachedEnd = (distanceFromEnd: number) => {
+    setShouldShowHasMore(false);
+  }
+
   return (
     <TouchableHighlightWrapper
       onPress={() => {
@@ -99,7 +104,7 @@ const Creatives: React.FC<CreativesProps> = ({
       <View style={styles.generalContainer}>
         <View style={styles.wrapper}>
           <RohText style={styles.title}>Creatives</RohText>
-          <View style={active ? styles.highlightActive : styles.highlightHidden} />
+          <View style={active && shouldShowHasMore ? styles.highlightActive : styles.highlightHidden} />
             <View style={styles.creativesContainer}>
               <View style={styles.columnContainer}>
                 <MultiColumnRoleNameList
@@ -109,7 +114,9 @@ const Creatives: React.FC<CreativesProps> = ({
                   ref={columnContainerRef}
                   setItemHeight={height => accumulateHeight(height)}
                   setContainerHeight={height => setContainerHeight(height)}
+                  setReachedEnd={(distanceFromEnd) => updateReachedEnd(distanceFromEnd)}
                 />
+                {shouldShowHasMore && <RohText style={styles.hasMore}>Press select for more...</RohText>}
               </View>
             </View>
           </View>
@@ -175,6 +182,14 @@ const styles = StyleSheet.create({
   columnContainer: {
     flex: 1,
   },
+  hasMore: {
+    color: Colors.defaultTextColor,
+    opacity: 0.8,
+    position: 'absolute',
+    bottom: scaleSize(10),
+    alignSelf: 'center',
+    backgroundColor: Colors.backgroundColorTransparent
+  }
 });
 
 export default Creatives;

--- a/src/components/EventDetailsComponents/index.tsx
+++ b/src/components/EventDetailsComponents/index.tsx
@@ -1,3 +1,4 @@
 export { default as General } from './components/General';
-export { default as CastAndCreatives } from './components/CastAndCreatives';
+export { default as Cast } from './components/Cast';
+export { default as Creatives } from './components/Creatives';
 export { default as Synopsis } from './components/Synopsis';

--- a/src/configs/eventDetailsConfig.ts
+++ b/src/configs/eventDetailsConfig.ts
@@ -1,6 +1,7 @@
 import {
   General,
-  CastAndCreatives,
+  Cast,
+  Creatives,
   Synopsis,
 } from '@components/EventDetailsComponents/';
 
@@ -18,10 +19,15 @@ export const eventDetailsSectionsConfig: {
     nextSectionTitle: 'CAST & MORE',
     Component: General,
   },
-  castAndCreatives: {
-    key: 'castAndCreatives',
+  cast: {
+    key: 'cast',
+    nextSectionTitle: 'CREATIVES & MORE',
+    Component: Cast,
+  },
+  creatives: {
+    key: 'creatives',
     nextSectionTitle: 'SYNOPSIS & MORE',
-    Component: CastAndCreatives,
+    Component: Creatives,
   },
   synopsis: {
     key: 'synopsis',

--- a/src/themes/Styleguide.tsx
+++ b/src/themes/Styleguide.tsx
@@ -7,6 +7,7 @@ export const Colors = Object.freeze({
   defaultTextColor: '#F1F1F1',
   searchDisplayBackgroundColor: '#4B5B7A',
   midGrey: '#7E91B4',
+  title: '#FFFFFF'
 });
 
 export const Images = Object.freeze({


### PR DESCRIPTION
As we discussed, I have tried to find a nice way to handle these large lists. Here are the highlights:

- The data is arranged in 1, 2 or 3 columns as appropriate (to the amount of data)
- When the amount of data is too large even for 3 columns, it becomes possible to scroll down
- When scrolling down is possible, a text appears at the bottom of the list challenging the user to press select for more data
- When the user presses select, highlight and scroll down the list
- Subsequent presses scroll up or down the list

This is a proposal, not UX-ready; I'm sure the UX team will have some nice suggestions on how to present this in terms of styling.
I'm proposing that we take next steps in a new issue, later on (after discussion and when appropriate priority-wise). Some things that could become separate issues later:

- Always show the "Press select for more" text when more data available (only shows first time)
- Rendering could be optimised, certainly
- How to hande really large lists (that would scroll past and miss the data in the middle)
- Handle press right instead of press select
- Cast and Creatives components can be made DRYer (they are almost identical)

Here's a vid of the changes with some q'n'd fake data ;) :

https://user-images.githubusercontent.com/7300069/132691314-8f602ced-4664-4b4c-bf66-70d820b5718d.mov

 
