### PR TITLE
Handle prismic urls

### DIFF
--- a/android/.project
+++ b/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>android</name>
+	<comment>Project android created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -137,3 +137,5 @@ There are also many full-featured feature flag services available such as [flags
      * updates every 30 mins
      * continues throughout app lifetime
      * fetches new content 
+
+Please note that we fetch a list of videos from Prismic in `store\videos\Sagas.ts`(`getVideoListLoopWorker()`). This list is filtered first by selecting videos from the Events store and selecting those with `isBroken` set to false, then further cross-referenced to the fetched list of videos filtered on video_type "performance". (In `General.tsx`). This result will be an array. In production the array should only contain one "performance" video, so we fetch the first element. There may be extra "performance" videos in the staging environment however.

--- a/src/components/EventDetailsComponents/components/General.tsx
+++ b/src/components/EventDetailsComponents/components/General.tsx
@@ -54,7 +54,24 @@ const General: React.FC<Props> = ({
     '',
   );
 
-  const addOrRemoveItemIdFromMyListHandler = () => {
+  const videos = get(event.data,
+    'vs_videos', []);
+  console.log('vids: ', videos);
+  const vidIsBroken = get(event.data,
+    ['vs_videos', '0', 'video', 'isBroken'],
+    false);
+  console.log('vidIsBroken is', vidIsBroken);
+  
+  const vidUrl = get(event.data,
+    ['vs_videos', '0', 'video', 'id'],
+    '');
+  console.log('vidUrl is', vidUrl);
+
+  const finalUrl = (vidUrl != '' && !vidIsBroken) ? 
+    'https://roh-stagev2.global.ssl.fastly.net/api/video-source?id=' + vidUrl :  
+    'https://video-ingestor-output-bucket.s3.eu-west-1.amazonaws.com/6565/manifest.m3u8';
+  
+    const addOrRemoveItemIdFromMyListHandler = () => {
     if (addOrRemoveBusyRef.current) {
       return;
     }
@@ -82,14 +99,16 @@ const General: React.FC<Props> = ({
           text: 'Watch now',
           hasTVPreferredFocus: true,
           onPress: () =>
+          {
             showPlayer({
               videoId: event.id,
-              url: 'https://video-ingestor-output-bucket.s3.eu-west-1.amazonaws.com/6565/manifest.m3u8',
+              url: finalUrl,
               title,
               poster:
                 'https://actualites.music-opera.com/wp-content/uploads/2019/09/14OPENING-superJumbo.jpg',
               subtitle: title,
-            }),
+            });
+          },
           onFocus: () => console.log('Watch now focus'),
           Icon: Watch,
         },

--- a/src/components/EventDetailsComponents/components/General.tsx
+++ b/src/components/EventDetailsComponents/components/General.tsx
@@ -73,8 +73,8 @@ const General: React.FC<Props> = ({
       videoListVideo.video_type === 'performance');
 
   let perfVidURL = '';
-  // Not sure if there can be several performance videos in the final data
-  // (there are in the test data) and how to choose which if so. Take first for now.
+  // We will receive a list, but there will only be one performance in the live 
+  // environment, so we can just take the first item.
   if(perfVids.length && perfVids[0].performanceVideoURL === '') { 
     dispatch(getPerformanceVideoURL(perfVids[0].id))
     selectedVideoId.current = perfVids[0].id;

--- a/src/components/EventDetailsComponents/components/General.tsx
+++ b/src/components/EventDetailsComponents/components/General.tsx
@@ -115,9 +115,7 @@ const General: React.FC<Props> = ({
           {
             showPlayer({
               videoId: event.id,
-              url: perfVidURL !== '' ? 
-                perfVidURL :
-                defaultPerfVidUrl,
+              url: perfVidURL,
               title,
               poster:
                 'https://actualites.music-opera.com/wp-content/uploads/2019/09/14OPENING-superJumbo.jpg',

--- a/src/components/EventDetailsComponents/components/General.tsx
+++ b/src/components/EventDetailsComponents/components/General.tsx
@@ -117,7 +117,7 @@ const General: React.FC<Props> = ({
               videoId: event.id,
               url: perfVidURL !== '' ? 
                 perfVidURL :
-                'https://video-ingestor-output-bucket.s3.eu-west-1.amazonaws.com/6565/manifest.m3u8',
+                defaultPerfVidUrl,
               title,
               poster:
                 'https://actualites.music-opera.com/wp-content/uploads/2019/09/14OPENING-superJumbo.jpg',

--- a/src/components/EventListComponents/components/DigitalEventItem.tsx
+++ b/src/components/EventListComponents/components/DigitalEventItem.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { scaleSize } from '@utils/scaleSize';
-import { TEventContainer } from '@services/types/models';
+import { TEventContainer, TEventVideo } from '@services/types/models';
 import RohText from '@components/RohText';
 import TouchableHighlightWrapper from '@components/TouchableHighlightWrapper';
 import get from 'lodash.get';
@@ -54,7 +54,7 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
           styleFocused={styles.imageContainerActive}
           style={styles.imageContainer}
           onFocus={() => {
-            ref?.current?.setDigigtalEvent(event);
+            ref?.current?.setDigitalEvent(event);
             navMenuManager.setNavMenuAccessible();
             if (typeof onFocus === 'function') {
               onFocus();

--- a/src/components/EventListComponents/components/Preview.tsx
+++ b/src/components/EventListComponents/components/Preview.tsx
@@ -14,7 +14,7 @@ import FastImage from 'react-native-fast-image';
 import { Colors } from '@themes/Styleguide';
 
 export type TPreviewRef = {
-  setDigigtalEvent?: (digitalEvent: TEventContainer) => void;
+  setDigitalEvent?: (digitalEvent: TEventContainer) => void;
 };
 
 type TPreviewProps = {};
@@ -26,7 +26,7 @@ const Preview = forwardRef<TPreviewRef, TPreviewProps>((props, ref) => {
   useImperativeHandle(
     ref,
     () => ({
-      setDigigtalEvent: (digitalEvent: TEventContainer) => {
+      setDigitalEvent: (digitalEvent: TEventContainer) => {
         if (mountedRef.current) {
           setEvent(digitalEvent.data);
         }

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -346,7 +346,6 @@ const Player: React.FC<TPlayerProps> = props => {
       controlRef.current.controlFadeIn();
     }
   }, [playerReady, autoPlay]);
-  console.log('url!!!!! is ', configuration.url);
   return (
     <SafeAreaView style={styles.defaultPlayerStyle}>
       <NativeBitMovinPlayer
@@ -372,7 +371,7 @@ const Player: React.FC<TPlayerProps> = props => {
         autoPlay={autoPlay}
       />
       {configuration.url === '' && 
-        <RohText style={styles.textDescription}>Video not available</RohText>
+        <RohText style={styles.textDescription}>Video not provided</RohText>
       }
     </SafeAreaView>
   );

--- a/src/components/Player/index.tsx
+++ b/src/components/Player/index.tsx
@@ -14,6 +14,8 @@ import {
 import { useAndroidBackHandler } from 'react-navigation-backhandler';
 import PlayerControls, { TPlayerControlsRef } from './PlayerControls';
 import { TBitmoviPlayerNativeProps } from '@services/types/bitmovinPlayer';
+import RohText from '@components/RohText';
+import { scaleSize } from '@utils/scaleSize';
 
 let NativeBitMovinPlayer: HostComponent<TBitmoviPlayerNativeProps> =
   requireNativeComponent('ROHBitMovinPlayer');
@@ -344,6 +346,7 @@ const Player: React.FC<TPlayerProps> = props => {
       controlRef.current.controlFadeIn();
     }
   }, [playerReady, autoPlay]);
+  console.log('url!!!!! is ', configuration.url);
   return (
     <SafeAreaView style={styles.defaultPlayerStyle}>
       <NativeBitMovinPlayer
@@ -368,6 +371,9 @@ const Player: React.FC<TPlayerProps> = props => {
         setSubtitle={setSubtitle}
         autoPlay={autoPlay}
       />
+      {configuration.url === '' && 
+        <RohText style={styles.textDescription}>Video not available</RohText>
+      }
     </SafeAreaView>
   );
 };
@@ -387,6 +393,14 @@ const styles = StyleSheet.create({
   controlsContainer: {
     position: 'absolute',
     bottom: 0,
+  },
+  textDescription: {
+    position: 'absolute',
+    flex: 1,
+    alignSelf: 'center',
+    top: scaleSize(180),
+    fontSize: scaleSize(80),
+    color: 'red'
   },
 });
 

--- a/src/configs/apiConfig.ts
+++ b/src/configs/apiConfig.ts
@@ -1,9 +1,14 @@
 import { getUniqueId } from 'react-native-device-info';
 
+const upgradeEnv='https://roh-upgrade.global.ssl.fastly.net/api';
+const stagingEnv='https://roh-stagev2.global.ssl.fastly.net/api';
+
 export const ApiConfig = Object.freeze({
-  host: 'https://roh-upgrade.global.ssl.fastly.net/api',
+  host: 'https://roh.org.uk/api/',
   deviceId: getUniqueId(),
+  manifestURL: stagingEnv,
   routes: {
     verifyDevice: '/auth/device',
+    videoSource: '/video-source?id=',
   },
 });

--- a/src/configs/eventDetailsConfig.ts
+++ b/src/configs/eventDetailsConfig.ts
@@ -5,14 +5,14 @@ import {
   Synopsis,
 } from '@components/EventDetailsComponents/';
 
-export type TEventDitailsSection = {
+export type TEventDetailsSection = {
   key: string;
   nextSectionTitle: string;
   Component: React.FC<any>;
 };
 
 export const eventDetailsSectionsConfig: {
-  [key: string]: TEventDitailsSection;
+  [key: string]: TEventDetailsSection;
 } = {
   general: {
     key: 'general',
@@ -36,7 +36,7 @@ export const eventDetailsSectionsConfig: {
   },
 };
 
-const collectionOfEventDetailsSections: Array<TEventDitailsSection> =
+const collectionOfEventDetailsSections: Array<TEventDetailsSection> =
   Object.values(eventDetailsSectionsConfig);
 
 export default collectionOfEventDetailsSections;

--- a/src/configs/prismicApiConfig.ts
+++ b/src/configs/prismicApiConfig.ts
@@ -5,9 +5,11 @@ export const prismicApiAccessToken =
 
 type TDocumentTypeList = {
   digitalEventDetails: string;
+  digitalEventVideo: string;
 };
 export const documentTypes: TDocumentTypeList = Object.freeze({
   digitalEventDetails: 'digital_event_details',
+  digitalEventVideo: 'digital_event_video'
 });
 
 export const refLabelOfPublishing = 'Staging';

--- a/src/layouts/appLayout.tsx
+++ b/src/layouts/appLayout.tsx
@@ -12,6 +12,10 @@ import {
   getEventListLoopStart,
   getEventListLoopStop,
 } from '@services/store/events/Slices';
+import {
+  getVideoListLoopStart,
+  getVideoListLoopStop
+} from '@services/store/videos/Slices';
 
 type TAppLayoutProps = {};
 const AppLayout: React.FC<TAppLayoutProps> = () => {
@@ -30,6 +34,7 @@ const AppLayout: React.FC<TAppLayoutProps> = () => {
         isAuthenticated
       ) {
         dispatch(getEventListLoopStart());
+        dispatch(getVideoListLoopStart());
       }
       if (
         appState.current === 'active' &&
@@ -37,6 +42,7 @@ const AppLayout: React.FC<TAppLayoutProps> = () => {
         isAuthenticated
       ) {
         dispatch(getEventListLoopStop());
+        dispatch(getVideoListLoopStop());
       }
       appState.current = nextAppState;
     };

--- a/src/screens/BalletDanceScreen/index.tsx
+++ b/src/screens/BalletDanceScreen/index.tsx
@@ -23,12 +23,12 @@ const BalletDanceScreen: React.FC<TBalletDanceScreenProps> = () => {
   const runningOnceRef = useRef<boolean>(false);
   useLayoutEffect(() => {
     if (
-      typeof previewRef.current?.setDigigtalEvent === 'function' &&
+      typeof previewRef.current?.setDigitalEvent === 'function' &&
       data.length &&
       !runningOnceRef.current
     ) {
       runningOnceRef.current = true;
-      previewRef.current.setDigigtalEvent(data[0]?.data[0]);
+      previewRef.current.setDigitalEvent(data[0]?.data[0]);
     }
   }, [data]);
   if (!data.length) {

--- a/src/screens/EventDetailsScreen/index.tsx
+++ b/src/screens/EventDetailsScreen/index.tsx
@@ -4,7 +4,7 @@ import { View, StyleSheet, ScrollView, Dimensions } from 'react-native';
 import { TEventContainer } from '@services/types/models';
 import collectionOfEventDetailsSections, {
   eventDetailsSectionsConfig,
-  TEventDitailsSection,
+  TEventDetailsSection,
 } from '@configs/eventDetailsConfig';
 import GoBack from '@components/GoBack';
 import Player from '@components/Player';
@@ -51,7 +51,7 @@ const EventDetailsScreen: React.FC<TEventDetalsScreenProps> = ({ route }) => {
   };
 
   const sectionsFactory = useCallback(
-    (item: TEventDitailsSection, index: number): JSX.Element | null => {
+    (item: TEventDetailsSection, index: number): JSX.Element | null => {
       const Component = item?.Component;
       if (Component === undefined) {
         return null;

--- a/src/screens/OperaMusicScreen/index.tsx
+++ b/src/screens/OperaMusicScreen/index.tsx
@@ -22,12 +22,12 @@ const OperaMusicScreen: React.FC<TOperaMusicScreenProps> = () => {
   const runningOnceRef = useRef<boolean>(false);
   useLayoutEffect(() => {
     if (
-      typeof previewRef.current?.setDigigtalEvent === 'function' &&
+      typeof previewRef.current?.setDigitalEvent === 'function' &&
       data.length &&
       !runningOnceRef.current
     ) {
       runningOnceRef.current = true;
-      previewRef.current.setDigigtalEvent(data[0]?.data[0]);
+      previewRef.current.setDigitalEvent(data[0]?.data[0]);
     }
   }, [data]);
   if (!data.length) {

--- a/src/services/apiClient/index.ts
+++ b/src/services/apiClient/index.ts
@@ -48,3 +48,6 @@ axiosClient.interceptors.response.use(
 
 export const verifyDevice = () =>
   axiosClient.get(ApiConfig.routes.verifyDevice);
+
+export const fetchVideoURL = (id: string) => 
+  axiosClient.get(ApiConfig.routes.videoSource + id, { baseURL: ApiConfig.manifestURL });

--- a/src/services/bitMovinPlayer/index.ts
+++ b/src/services/bitMovinPlayer/index.ts
@@ -59,7 +59,7 @@ export const removeItemsFromSavedPositionList = async (
     );
   } catch (error) {
     logError(
-      'Something went wromg with removing from BitMovinPlayerSavedPositionList',
+      'Something went wrong with removing from BitMovinPlayerSavedPositionList',
       error,
     );
   } finally {

--- a/src/services/myList/index.ts
+++ b/src/services/myList/index.ts
@@ -84,7 +84,7 @@ export const getMyList = async (): Promise<Array<string>> => {
       : JSON.parse(savedMyList);
     return parsedMyList;
   } catch (error) {
-    logError('Something went wromg with getting MyList', error);
+    logError('Something went wrong with getting MyList', error);
     return [];
   }
 };

--- a/src/services/prismicApiClient/index.ts
+++ b/src/services/prismicApiClient/index.ts
@@ -70,4 +70,19 @@ export const getDigitalEventDetails = (
     queryOptions: queryObj.queryOptions,
   });
 
+  export const getVideoDetails = (
+    queryObj: TQueryObj = {},
+  ): Promise<ApiSearchResponse> =>
+    commonQuery({
+      queryPredicates: [
+        Prismic.Predicates.at('document.type', documentTypes.digitalEventVideo),
+        ...[
+          ...(Array.isArray(queryObj.queryPredicates)
+            ? queryObj.queryPredicates
+            : []),
+        ],
+      ],
+      queryOptions: queryObj.queryOptions,
+    });
+
 export default prismicApiClient;

--- a/src/services/store/auth/Sagas.ts
+++ b/src/services/store/auth/Sagas.ts
@@ -18,6 +18,7 @@ import { verifyDevice } from '@services/apiClient';
 import { logError } from '@utils/loger';
 import { TAuthResponseError } from '@services/types/authReqResp';
 import { authBreakingTime } from '@configs/globalConfig';
+import { getVideoListLoopStart } from '../videos/Slices';
 
 export default function* authRootSagas() {
   yield all([call(loginLoopWatcher)]);
@@ -60,6 +61,7 @@ function* loginLoopWorker(): any {
       if (response?.data?.data?.attributes?.customerId) {
         runLoop = false;
         yield put(getEventListLoopStart());
+        yield put(getVideoListLoopStart());
         yield put(checkDeviceSuccess(response.data));
       } else if (response?.data?.errors?.length) {
         const errObj: TAuthResponseError = response.data.errors[0];

--- a/src/services/store/events/Sagas.ts
+++ b/src/services/store/events/Sagas.ts
@@ -11,7 +11,6 @@ import {
   all,
   call,
   cancel,
-  delay,
   fork,
   put,
   select,
@@ -22,6 +21,7 @@ import { logError } from '@utils/loger';
 import { getDigitalEventDetails } from '@services/prismicApiClient';
 import ApiSearchResponse from '@prismicio/client/types/ApiSearchResponse';
 import { addItemToPrevSearchList } from '@services/previousSearch';
+import { bigDelay } from '@utils/bigDelay';
 
 export default function* eventRootSagas() {
   yield all([
@@ -166,11 +166,4 @@ function groupDigitalEvents(digitalEventsDetail: Array<any>): any {
       eventGroups: {},
     },
   );
-}
-
-function* bigDelay(seconds: number) {
-  const sec: number = Math.ceil(seconds / 10000);
-  for (let i = 0; i < sec; i++) {
-    yield delay(10000);
-  }
 }

--- a/src/services/store/index.ts
+++ b/src/services/store/index.ts
@@ -10,11 +10,16 @@ import {
   reducer as eventsReducer,
   name as eventsReducerName,
 } from '@services/store/events/Slices';
+import {
+  reducer as videoURLsReducer,
+  name as videoURLsReducerName,
+} from '@services/store/videos/Slices';
 import { rootSaga } from '@services/store/rootSaga';
 
 const rootReducer = combineReducers({
   [authReducerName]: authReducer,
   [eventsReducerName]: eventsReducer,
+  [videoURLsReducerName]: videoURLsReducer
 });
 
 const sagaMiddleware = createSagaMiddleware();

--- a/src/services/store/rootSaga.ts
+++ b/src/services/store/rootSaga.ts
@@ -1,7 +1,8 @@
 import { all, call } from 'redux-saga/effects';
 import authFlowSagas from './auth/Sagas';
 import eventRootSagas from './events/Sagas';
+import videoRootSagas from './videos/Sagas';
 export function* rootSaga() {
   console.log('Root Saga Run');
-  yield all([call(authFlowSagas), call(eventRootSagas)]);
+  yield all([call(authFlowSagas), call(eventRootSagas), call(videoRootSagas)]);
 }

--- a/src/services/store/videos/Sagas.ts
+++ b/src/services/store/videos/Sagas.ts
@@ -1,0 +1,40 @@
+import {
+  getPerformanceVideoURL,
+  performanceVideoURLReceived,
+  getPerformanceVideoURLError,
+} from '@services/store/videos/Slices';
+
+import {
+  all,
+  call,
+  put,
+  takeEvery,
+} from 'redux-saga/effects';
+import { fetchVideoURL } from '@services/apiClient';
+import { PayloadAction } from '@reduxjs/toolkit/dist/createAction';
+import { logError } from '@utils/loger';
+
+export default function* getVideoURLRootSagas() {
+   yield all([call(getVideoURLWatcher)]);
+}
+
+function* getVideoURLWatcher() {
+  yield takeEvery(getPerformanceVideoURL.toString(), getVideoURLWorker);
+}
+
+function* getVideoURLWorker(action: PayloadAction<string>) {
+  try {
+    const response: any = yield call(fetchVideoURL, action.payload);
+    if (response?.data?.data?.attributes?.hlsManifestUrl) {
+      yield put(performanceVideoURLReceived(response?.data?.data?.attributes?.hlsManifestUrl));
+    } else if (response?.data?.errors?.length) {
+      const errString = response.data.errors[0].title;
+      yield put(getPerformanceVideoURLError(errString));
+    } else {
+      throw Error();
+    }
+  } catch (err) {
+    logError('Something went wrong', err);
+    yield put(yield put(getPerformanceVideoURLError(err)));
+  }
+}

--- a/src/services/store/videos/Sagas.ts
+++ b/src/services/store/videos/Sagas.ts
@@ -118,7 +118,6 @@ function* getVideoListLoopWorker(): any {
       logError('Something went wrong with the Prismic request')
     }
     if(result.length) {
-      console.log('vids result: ', result);
       eventVideoList.push(
         ...result.reduce((acc: Array<TEventVideo>, video: any, index) => {
           if(video.data?.video?.video_type) {

--- a/src/services/store/videos/Sagas.ts
+++ b/src/services/store/videos/Sagas.ts
@@ -1,4 +1,7 @@
 import {
+  getVideoListLoopStart,
+  getVideoListLoopSuccess,
+  getVideoListLoopStop,
   getPerformanceVideoURL,
   performanceVideoURLReceived,
   getPerformanceVideoURLError,
@@ -8,18 +11,50 @@ import {
   all,
   call,
   put,
+  take,
   takeEvery,
+  fork,
+  cancel,
 } from 'redux-saga/effects';
 import { fetchVideoURL } from '@services/apiClient';
-import { PayloadAction } from '@reduxjs/toolkit/dist/createAction';
+import { PayloadAction, ActionCreatorWithoutPayload } from '@reduxjs/toolkit/dist/createAction';
 import { logError } from '@utils/loger';
+import { Task } from 'redux-saga';
+import { bigDelay } from '@utils/bigDelay';
+import ApiSearchResponse from '@prismicio/client/types/ApiSearchResponse';
+import { getVideoDetails } from '@services/prismicApiClient';
 
 export default function* getVideoURLRootSagas() {
-   yield all([call(getVideoURLWatcher)]);
+  yield all([
+     call(getVideoURLWatcher),
+     call(getVideoListLoopWatcher)
+  ]);
 }
 
 function* getVideoURLWatcher() {
   yield takeEvery(getPerformanceVideoURL.toString(), getVideoURLWorker);
+}
+
+function* getVideoListLoopWatcher() {
+  let task: null | Task = null;
+  while (true) {
+    const action: ActionCreatorWithoutPayload<string> = yield take([
+      getVideoListLoopStart.toString(),
+      getVideoListLoopStop.toString(),
+    ]);
+    if (
+      action.type === getVideoListLoopStart.toString() &&
+      (!task || !task.isRunning())
+    ) {
+      task = yield fork(getVideoListLoopWorker);
+      continue;
+    }
+
+    if (action.type === getVideoListLoopStop.toString() && task) {
+      yield cancel(task);
+      task = null;
+    }
+  }
 }
 
 function* getVideoURLWorker(action: PayloadAction<string>) {
@@ -34,7 +69,30 @@ function* getVideoURLWorker(action: PayloadAction<string>) {
       throw Error();
     }
   } catch (err) {
-    logError('Something went wrong', err);
-    yield put(yield put(getPerformanceVideoURLError(err)));
+    logError('Something went wrong retrieving video url', err);
+    yield put(getPerformanceVideoURLError(err));
+  }
+}
+
+function* getVideoListLoopWorker(): any {
+  console.log('enter loop');
+  while (true) {
+    console.log('Working!');  
+    const result = [];  
+    try {
+      const initialResponse: ApiSearchResponse = yield call(
+        getVideoDetails,
+      );
+      console.log("Got video details!");
+      result.push(...initialResponse.results);
+    } catch (err) {
+      logError('Something went wrong with the Prismic request')
+    }
+    if(result.length) {
+      yield put(
+        getVideoListLoopSuccess("Just testing!")
+      );
+    }
+    yield call(bigDelay, 30 * 60 * 1000);
   }
 }

--- a/src/services/store/videos/Selectors.ts
+++ b/src/services/store/videos/Selectors.ts
@@ -8,4 +8,8 @@ export const performanceVideoURLSelector = (store: {
 
 export const performanceVideoURLErrorSelector = (store: {
   [key: string]: any;
-}) => store.videoURLs.performanceVideoURLErrorString
+}) => store.videoURLs.performanceVideoURLErrorString;
+
+export const videoListSelector = (store: {
+  [key: string]: any;
+}) => store.videoURLs.eventVideoList;

--- a/src/services/store/videos/Selectors.ts
+++ b/src/services/store/videos/Selectors.ts
@@ -1,10 +1,4 @@
-export const performanceVideoURLHasLoadedSelector = (store: {
-  [key: string]: any 
-}) => store.videoURLs.performanceVideoURLhasLoaded;
-
-export const performanceVideoURLSelector = (store: {
-  [key: string]: any 
-}) => store.videoURLs.performanceVideoURL;
+import { TEventVideo } from "@services/types/models";
 
 export const performanceVideoURLErrorSelector = (store: {
   [key: string]: any;
@@ -13,3 +7,9 @@ export const performanceVideoURLErrorSelector = (store: {
 export const videoListSelector = (store: {
   [key: string]: any;
 }) => store.videoURLs.eventVideoList;
+
+export const videoListItemSelector =
+  (id: string) => (store: { [key: string]: any }) => {
+    const eventVideo = store.videoURLs.eventVideoList.find((eventVideo: TEventVideo) => eventVideo.id === id);
+    return eventVideo;
+  }

--- a/src/services/store/videos/Selectors.ts
+++ b/src/services/store/videos/Selectors.ts
@@ -1,0 +1,11 @@
+export const performanceVideoURLHasLoadedSelector = (store: {
+  [key: string]: any 
+}) => store.videoURLs.performanceVideoURLhasLoaded;
+
+export const performanceVideoURLSelector = (store: {
+  [key: string]: any 
+}) => store.videoURLs.performanceVideoURL;
+
+export const performanceVideoURLErrorSelector = (store: {
+  [key: string]: any;
+}) => store.videoURLs.performanceVideoURLErrorString

--- a/src/services/store/videos/Slices.ts
+++ b/src/services/store/videos/Slices.ts
@@ -1,0 +1,42 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { PayloadAction } from '@reduxjs/toolkit/src/createAction';
+
+interface VideoURLsState {
+  performanceVideoURLhasLoaded: boolean;
+  performanceVideoURL: string;
+  performanceVideoURLErrorString: string;
+  // TODO: if necessary, handle other types of videos
+  // Currently available: trailers and behind-the-scenes videos
+}
+
+const initialState: VideoURLsState = {
+  performanceVideoURLhasLoaded: false,
+  performanceVideoURL: '',
+  performanceVideoURLErrorString: ''
+};
+
+const videoURLsSlice = createSlice({
+  name: 'videoURLs',
+  initialState,
+  reducers: {
+    getPerformanceVideoURL: (state: VideoURLsState, action: PayloadAction<string>) => {
+      (state: VideoURLsState) => state
+    },
+    performanceVideoURLReceived: (state: VideoURLsState, action: PayloadAction<string>) => {
+      state.performanceVideoURL = action.payload;
+      state.performanceVideoURLhasLoaded = true;
+    },
+    getPerformanceVideoURLError: (state: VideoURLsState, action: PayloadAction<string>) => {
+      state.performanceVideoURLErrorString = action.payload;
+      state.performanceVideoURLhasLoaded = false;
+    },
+  }
+});
+
+export const {
+  getPerformanceVideoURL,
+  performanceVideoURLReceived,
+  getPerformanceVideoURLError,
+} = videoURLsSlice.actions;
+
+export const { reducer, name } = videoURLsSlice;

--- a/src/services/store/videos/Slices.ts
+++ b/src/services/store/videos/Slices.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, isDraft } from '@reduxjs/toolkit';
 import { PayloadAction } from '@reduxjs/toolkit/src/createAction';
 import { TEventVideo } from '@services/types/models';
 
@@ -34,8 +34,22 @@ const videoURLsSlice = createSlice({
       (state: VideoState) => state
     },
     performanceVideoURLReceived: (state: VideoState, action: PayloadAction<{url: string, id: string}>) => {
-      console.log('url is ', action.payload.url, ' id is ', action.payload.id);
-      // TODO: update list item with url
+      const { id, url } = action.payload;
+      
+      state.eventVideoList = state.eventVideoList.map((eventVideo, _index) => {
+        if(eventVideo.id !== id) {
+          return eventVideo;
+        }
+        const newEventVideo = {
+          id,
+          performanceVideoURL: url,
+          video_type: eventVideo.video_type
+        };
+        return {
+          ...eventVideo,
+          ...newEventVideo
+        }
+      });
     },
     getPerformanceVideoURLError: (state: VideoState, action: PayloadAction<string>) => {
       state.performanceVideoURLErrorString = action.payload;

--- a/src/services/store/videos/Slices.ts
+++ b/src/services/store/videos/Slices.ts
@@ -1,19 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { PayloadAction } from '@reduxjs/toolkit/src/createAction';
+import { TEventVideo } from '@services/types/models';
 
 interface VideoState {
-  performanceVideoURLhasLoaded: boolean;
-  performanceVideoURL: string;
   performanceVideoURLErrorString: string;
-  videosLoaded: boolean;
   // TODO: if necessary, handle other types of videos
   // Currently available: trailers and behind-the-scenes videos
+  eventVideoList: Array<TEventVideo>; // Get the event type from here 
+  videosLoaded: boolean;
 }
 
 const initialState: VideoState = {
-  performanceVideoURLhasLoaded: false,
-  performanceVideoURL: '',
   performanceVideoURLErrorString: '',
+  eventVideoList: [],
   videosLoaded: false
 };
 
@@ -27,20 +26,19 @@ const videoURLsSlice = createSlice({
     getVideoListLoopStop: (state: VideoState) => {
       (state: VideoState) => state
     },
-    getVideoListLoopSuccess: (state: VideoState, action: PayloadAction<string>)  => {
-      console.log("payload action: ", action.payload);
+    getVideoListLoopSuccess: (state: VideoState, action: PayloadAction<Array<TEventVideo>>)  => {
+      state.eventVideoList = action.payload;
       state.videosLoaded = true;
     },
     getPerformanceVideoURL: (state: VideoState, action: PayloadAction<string>) => {
       (state: VideoState) => state
     },
-    performanceVideoURLReceived: (state: VideoState, action: PayloadAction<string>) => {
-      state.performanceVideoURL = action.payload;
-      state.performanceVideoURLhasLoaded = true;
+    performanceVideoURLReceived: (state: VideoState, action: PayloadAction<{url: string, id: string}>) => {
+      console.log('url is ', action.payload.url, ' id is ', action.payload.id);
+      // TODO: update list item with url
     },
     getPerformanceVideoURLError: (state: VideoState, action: PayloadAction<string>) => {
       state.performanceVideoURLErrorString = action.payload;
-      state.performanceVideoURLhasLoaded = false;
     },
   }
 });

--- a/src/services/store/videos/Slices.ts
+++ b/src/services/store/videos/Slices.ts
@@ -1,32 +1,44 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { PayloadAction } from '@reduxjs/toolkit/src/createAction';
 
-interface VideoURLsState {
+interface VideoState {
   performanceVideoURLhasLoaded: boolean;
   performanceVideoURL: string;
   performanceVideoURLErrorString: string;
+  videosLoaded: boolean;
   // TODO: if necessary, handle other types of videos
   // Currently available: trailers and behind-the-scenes videos
 }
 
-const initialState: VideoURLsState = {
+const initialState: VideoState = {
   performanceVideoURLhasLoaded: false,
   performanceVideoURL: '',
-  performanceVideoURLErrorString: ''
+  performanceVideoURLErrorString: '',
+  videosLoaded: false
 };
 
 const videoURLsSlice = createSlice({
   name: 'videoURLs',
   initialState,
   reducers: {
-    getPerformanceVideoURL: (state: VideoURLsState, action: PayloadAction<string>) => {
-      (state: VideoURLsState) => state
+    getVideoListLoopStart: (state: VideoState) => {
+      (state: VideoState) => state
     },
-    performanceVideoURLReceived: (state: VideoURLsState, action: PayloadAction<string>) => {
+    getVideoListLoopStop: (state: VideoState) => {
+      (state: VideoState) => state
+    },
+    getVideoListLoopSuccess: (state: VideoState, action: PayloadAction<string>)  => {
+      console.log("payload action: ", action.payload);
+      state.videosLoaded = true;
+    },
+    getPerformanceVideoURL: (state: VideoState, action: PayloadAction<string>) => {
+      (state: VideoState) => state
+    },
+    performanceVideoURLReceived: (state: VideoState, action: PayloadAction<string>) => {
       state.performanceVideoURL = action.payload;
       state.performanceVideoURLhasLoaded = true;
     },
-    getPerformanceVideoURLError: (state: VideoURLsState, action: PayloadAction<string>) => {
+    getPerformanceVideoURLError: (state: VideoState, action: PayloadAction<string>) => {
       state.performanceVideoURLErrorString = action.payload;
       state.performanceVideoURLhasLoaded = false;
     },
@@ -34,6 +46,9 @@ const videoURLsSlice = createSlice({
 });
 
 export const {
+  getVideoListLoopStart,
+  getVideoListLoopSuccess,
+  getVideoListLoopStop,
   getPerformanceVideoURL,
   performanceVideoURLReceived,
   getPerformanceVideoURLError,

--- a/src/services/types/models.ts
+++ b/src/services/types/models.ts
@@ -199,3 +199,9 @@ export type TBitMovinPlayerSavedPosition = {
   position: string;
   eventId?: string;
 };
+
+export type TEventVideo = {
+  id: string;
+  video_type: 'performance' | 'trailer' | 'behind_the_scenes';
+  performanceVideoURL: string;
+};

--- a/src/services/types/models.ts
+++ b/src/services/types/models.ts
@@ -72,7 +72,9 @@ export type TVSTitle = {
 
 export type TVSVideo = {
   video: {
+    id: string;
     link_type: string;
+    isBroken: boolean;
   };
 };
 

--- a/src/utils/bigDelay.ts
+++ b/src/utils/bigDelay.ts
@@ -1,0 +1,9 @@
+
+import { delay } from 'redux-saga/effects';
+
+export function* bigDelay(seconds: number) {
+    const sec: number = Math.ceil(seconds / 10000);
+    for (let i = 0; i < sec; i++) {
+        yield delay(10000);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6691,7 +6691,7 @@ react-native-svg@^12.2.0:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
-"react-native@npm:react-native-tvos@0.63.4":
+"react-native@npm:react-native-tvos@0.63.4-0":
   version "0.63.4-0"
   resolved "https://registry.npmjs.org/react-native-tvos/-/react-native-tvos-0.63.4-0.tgz#f717aeaf799fe2b35fae3c12e3b475d2ebad94fb"
   integrity sha512-bOF5BDGm1O8LJ+btBeVu8S/VpjyXm8EbC/HAdStlRmgiddQiO8cKjgt/rZhcGQz7U9kwCWiF6hKBILT7kB1+pA==


### PR DESCRIPTION
**What?**
The app currently uses a hardcoded url in the player. This PR fetches a url from Prismic based on a videoId which is stored in app state. If no such video stream is available it defaults to the original hardcoded url.

**Why?**
This enables us to see the correct content for the event.

**How?**

To be able to fetch a url from Prismic, we need an ID for the video in question.

In the existing event data state in the app, we are able to harvest a list of video IDs, filtering out the ones that have the `isBroken` field set to false. The filtered list may contain several videos and several types of video - ("performance", "behind the scenes" or "trailer"). 

We are currently only interested in "performance" videos, so we need to identify these. That data is not available in the app state, so I needed to build a new list of data fetched from Prismic, in parallel to the event data. That list of videos can then be filtered to match the ids of the filtered video list from events mentioned in the last paragraph. I tried to make the saga that does this as consistent as possible with the code that fetches the events, such that I was able to factor out some common code there (for the time delay).

By this stage, we have one or more IDs for performance videos. NB: I chose to take the first at this stage, which I have confirmed now is the appropriate behaviour even in the production environment.
 
I also added a saga to fetch the url when we have a url available (ie. when there is an ID in the list we created above). The url is then placed in the state for that video in the list that I originally fetched from Prismic.