### PR TITLE
#54 displaying user email at settings sections

### DIFF
--- a/src/components/SettingsComponents/components/Account.tsx
+++ b/src/components/SettingsComponents/components/Account.tsx
@@ -1,0 +1,57 @@
+import RohText from '@components/RohText';
+import { Colors } from '@themes/Styleguide';
+import { scaleSize } from '@utils/scaleSize';
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { shallowEqual, useSelector } from 'react-redux';
+import { userEmailSelector } from '@services/store/auth/Selectors';
+
+type TAccountProps = {};
+
+const Account: React.FC<TAccountProps> = () => {
+  const userEmail: string = useSelector(userEmailSelector, shallowEqual);
+  return (
+    <View style={styles.root}>
+      <View style={styles.titleContainer}>
+        <RohText style={styles.titleText}>ACCOUNT NAME</RohText>
+      </View>
+      <View style={styles.userEmailContainer}>
+        <RohText style={styles.userEmailText}>{userEmail}</RohText>
+      </View>
+    </View>
+  );
+};
+
+export default Account;
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    paddingTop: scaleSize(42),
+    marginLeft: scaleSize(80),
+    marginRight: scaleSize(338),
+  },
+  titleContainer: {
+    marginBottom: scaleSize(54),
+  },
+  titleText: {
+    fontSize: scaleSize(26),
+    lineHeight: scaleSize(30),
+    letterSpacing: scaleSize(1),
+    color: Colors.tVMidGrey,
+  },
+  userEmailContainer: {
+    minHeight: scaleSize(80),
+    minWidth: scaleSize(486),
+    backgroundColor: Colors.tvMidGreyWith50Alpha,
+    justifyContent: 'center',
+    paddingLeft: scaleSize(24),
+  },
+  userEmailText: {
+    fontSize: scaleSize(26),
+    lineHeight: scaleSize(30),
+    letterSpacing: scaleSize(1),
+    color: Colors.defaultTextColor,
+    opacity: 1,
+  },
+});

--- a/src/components/SettingsComponents/index.tsx
+++ b/src/components/SettingsComponents/index.tsx
@@ -1,3 +1,4 @@
 export { default as SettingsNavMenuItem } from './commonControl/SettingsNavMenuItem';
 export { default as SignOut } from './components/SignOut';
 export { default as SwitchSubscriptionMode } from './components/SwitchSubscriptionMode';
+export { default as Account } from './components/Account';

--- a/src/configs/settingsConfig.ts
+++ b/src/configs/settingsConfig.ts
@@ -1,6 +1,7 @@
 import {
   SignOut,
   SwitchSubscriptionMode,
+  Account,
 } from '@components/SettingsComponents';
 
 export const settingsTitle = 'SETTINGS';
@@ -22,7 +23,7 @@ export const settingsSectionsConfig: {
   account: {
     key: 'account',
     navMenuItemTitle: 'ACCOUNT',
-    ContentComponent: () => null,
+    ContentComponent: Account,
   },
   signOut: {
     key: 'signOut',

--- a/src/services/store/auth/Selectors.ts
+++ b/src/services/store/auth/Selectors.ts
@@ -13,3 +13,6 @@ export const deviceAuthenticatedErrorSelector = (store: {
 
 export const subscribedModeSelector = (store: { [key: string]: any }) =>
   store.auth.fullSubscription;
+
+export const userEmailSelector = (store: { [key: string]: any }) =>
+  store.auth.userEmail;

--- a/src/services/store/auth/Slices.ts
+++ b/src/services/store/auth/Slices.ts
@@ -8,6 +8,7 @@ interface AuthState {
   showIntroScreen: boolean;
   errorString: string;
   fullSubscription: boolean;
+  userEmail: string;
 }
 
 const initialState: AuthState = {
@@ -18,6 +19,7 @@ const initialState: AuthState = {
   showIntroScreen: true,
   errorString: '',
   fullSubscription: false,
+  userEmail: '',
 };
 
 const appSlice = createSlice({
@@ -42,6 +44,7 @@ const appSlice = createSlice({
       state.isLoading = false;
       state.showIntroScreen = false;
       state.errorString = '';
+      state.userEmail = payload.data.attributes.email;
     },
     checkDeviceError: (state, { payload }) => {
       state.devicePin = payload?.detail || '';

--- a/src/themes/Styleguide.tsx
+++ b/src/themes/Styleguide.tsx
@@ -8,6 +8,7 @@ export const Colors = Object.freeze({
   searchDisplayBackgroundColor: '#4B5B7A',
   midGrey: '#7E91B4',
   tVMidGrey: '#6887B6',
+  tvMidGreyWith50Alpha: '#364b6b',
   title: '#FFFFFF',
   subtitlesActiveBackground: '#1866DC',
   streamPrimary: '#1866DC',


### PR DESCRIPTION
**What?**
#54 added ability to show user email in the account section of the settings screen
**Why?**
**How?**

**How to test?**
![Quick Camera Image 2021-12-01 at 4 13 55 PM](https://user-images.githubusercontent.com/23078591/144250063-7de3a0a7-6882-4015-87d7-81f03ed0b55d.png)

