### PR TITLE
#110 turn off firestick screensaver when the tv player is running

### DIFF
--- a/android/app/src/main/res/layout/player_container.xml
+++ b/android/app/src/main/res/layout/player_container.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:keepScreenOn="true"
     android:orientation="vertical">
     <RelativeLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
#110 FireTV screensaver kicking in.
**What?**

turn off the firestick screensaver when the tv player is running

**Why?**

Useful for watching longtime videos

**How?**

added parameter  android:keepScreenOn="true" to player layout for android

**How to test?**

try to watch a longtime video and don't press any buttons on the remote control. You don't need to see any screensavers.
