### PR TITLE
Minimum resume time and resume time rollback

### DIFF
--- a/src/components/EventDetailsComponents/components/General.tsx
+++ b/src/components/EventDetailsComponents/components/General.tsx
@@ -30,6 +30,7 @@ import Prismic from '@prismicio/client';
 import { getSubscribeInfo, fetchVideoURL } from '@services/apiClient';
 import { getVideoDetails } from '@services/prismicApiClient';
 import { getBitMovinSavedPosition } from '@services/bitMovinPlayer';
+import { resumeRollbackTime, minResumeTime } from '@configs/bitMovinPlayerConfig';
 
 type Props = {
   event: TEventContainer;
@@ -118,9 +119,13 @@ const General: React.FC<Props> = ({
         videoFromPrismic.id,
         event.id,
       );
-      if (videoPositionInfo && videoPositionInfo?.position) {
+      if (videoPositionInfo && 
+        videoPositionInfo?.position && 
+        parseInt(videoPositionInfo?.position) > minResumeTime) {
         const fromTime = new Date(0);
-        fromTime.setSeconds(parseInt(videoPositionInfo.position));
+        const intPosition = parseInt(videoPositionInfo.position)
+        const rolledBackPos = intPosition - resumeRollbackTime;
+        fromTime.setSeconds(intPosition);
         globalModalManager.openModal({
           hasBackground: true,
           hasLogo: true,
@@ -136,7 +141,7 @@ const General: React.FC<Props> = ({
                   poster:
                     'https://actualites.music-opera.com/wp-content/uploads/2019/09/14OPENING-superJumbo.jpg',
                   subtitle: '',
-                  position: videoPositionInfo.position,
+                  position: rolledBackPos.toString(),
                   eventId: event.id,
                   savePosition: true,
                 });

--- a/src/configs/bitMovinPlayerConfig.ts
+++ b/src/configs/bitMovinPlayerConfig.ts
@@ -1,2 +1,4 @@
 export const bitMovinPlayerKey = '@bitMovinPlayer';
 export const continueWatchingRailTitle = 'Continue Watching';
+export const minResumeTime = 5;
+export const resumeRollbackTime = 2;


### PR DESCRIPTION
**What?**

1. If the user has only viewed 5 seconds or less, don't show the resume/restart dialog; instead, play directly from start
2. When resuming, rollback (up to) 2 seconds before the resume time.

**Why?**

1. No need for resuming if the user has only just started watching a stream
2. Ensures that the user doesn't miss the start of the resumed stream

**How?**

Added a couple of bitMovinPlayerConfig constants to make it easy to alter in future.

**Testing?**

1. Start stream, exit before 5 secs has passed. Restart, should restart from 0 without showing dialog.
2. Start stream, exit after 5 secs has passed. Restart, should show resume/restart dialog
3. Start stream, exit after 5 secs has passed. Resume when shown dialog, noting the time. The resume time should be up to seconds less than the shown resume time.

Resolves #121 
