### PR TITLE
Feature/continue watching text

### DIFF
--- a/src/components/EventDetailsComponents/components/General.tsx
+++ b/src/components/EventDetailsComponents/components/General.tsx
@@ -30,7 +30,10 @@ import Prismic from '@prismicio/client';
 import { getSubscribeInfo, fetchVideoURL } from '@services/apiClient';
 import { getVideoDetails } from '@services/prismicApiClient';
 import { getBitMovinSavedPosition } from '@services/bitMovinPlayer';
-import { resumeRollbackTime, minResumeTime } from '@configs/bitMovinPlayerConfig';
+import {
+  resumeRollbackTime,
+  minResumeTime,
+} from '@configs/bitMovinPlayerConfig';
 
 type Props = {
   event: TEventContainer;
@@ -44,12 +47,13 @@ const General: React.FC<Props> = ({
   event,
   showPlayer,
   nextScreenText = 'Some Screen',
-  continueWatching
+  continueWatching,
 }) => {
   const generalMountedRef = useRef<boolean | undefined>(false);
   const addOrRemoveBusyRef = useRef<boolean>(true);
   const [existInMyList, setExistInMyList] = useState<boolean>(false);
-  const [showContinueWatching, setShowContinueWatching] = useState<boolean>(false);
+  const [showContinueWatching, setShowContinueWatching] =
+    useState<boolean>(false);
 
   const title: string =
     get(event.data, ['vs_event_details', 'title'], '').replace(
@@ -71,7 +75,7 @@ const General: React.FC<Props> = ({
   const videos = get(event.data, 'vs_videos', []).map(({ video }) => video.id);
 
   const updateContinueWatching = async () => {
-    if(continueWatching) {
+    if (continueWatching) {
       return;
     }
     const result = await Promise.all([
@@ -86,7 +90,7 @@ const General: React.FC<Props> = ({
     ) {
       return;
     }
-    
+
     if (result[0]?.data?.data?.attributes?.isSubscriptionActive) {
       const videoFromPrismic = result[1].results.find(
         prismicResponseResult =>
@@ -101,11 +105,16 @@ const General: React.FC<Props> = ({
         videoFromPrismic.id,
         event.id,
       );
-      if(videoPositionInfo !== null) { 
+      if (
+        videoPositionInfo !== null &&
+        parseInt(videoPositionInfo.position) > minResumeTime &&
+        generalMountedRef &&
+        generalMountedRef.current
+      ) {
         setShowContinueWatching(true);
       }
     }
-  }
+  };
 
   const getPerformanceVideoUrl = async (
     ref?: RefObject<TouchableHighlight>,
@@ -159,11 +168,13 @@ const General: React.FC<Props> = ({
         videoFromPrismic.id,
         event.id,
       );
-      if (videoPositionInfo && 
-        videoPositionInfo?.position && 
-        parseInt(videoPositionInfo?.position) > minResumeTime) {
+      if (
+        videoPositionInfo &&
+        videoPositionInfo?.position &&
+        parseInt(videoPositionInfo?.position) > minResumeTime
+      ) {
         const fromTime = new Date(0);
-        const intPosition = parseInt(videoPositionInfo.position)
+        const intPosition = parseInt(videoPositionInfo.position);
         const rolledBackPos = intPosition - resumeRollbackTime;
         fromTime.setSeconds(intPosition);
         globalModalManager.openModal({
@@ -231,7 +242,7 @@ const General: React.FC<Props> = ({
               }
             });
           },
-          title: "Player Error",
+          title: 'Player Error',
           subtitle: err.message,
         },
       });
@@ -279,7 +290,7 @@ const General: React.FC<Props> = ({
               }
             });
           },
-          title: "Player Error",
+          title: 'Player Error',
           subtitle: err.message,
         },
       });
@@ -311,7 +322,10 @@ const General: React.FC<Props> = ({
       [EActionButtonListType.common]: [
         {
           key: 'WatchNow',
-          text: continueWatching || showContinueWatching ? 'Continue watching' : 'Watch now', 
+          text:
+            continueWatching || showContinueWatching
+              ? 'Continue watching'
+              : 'Watch now',
           hasTVPreferredFocus: true,
           onPress: getPerformanceVideoUrl,
           onFocus: () => console.log('Watch now focus'),
@@ -356,11 +370,16 @@ const General: React.FC<Props> = ({
 
   useEffect(() => {
     generalMountedRef.current = true;
+    return () => {
+      if (generalMountedRef.current) {
+        generalMountedRef.current = false;
+      }
+    };
   }, []);
 
   useEffect(() => {
-      updateContinueWatching();
-  }, [])
+    updateContinueWatching();
+  }, []);
 
   return (
     <View style={styles.generalContainer}>

--- a/src/components/EventListComponents/components/DigitalEventItem.tsx
+++ b/src/components/EventListComponents/components/DigitalEventItem.tsx
@@ -16,12 +16,13 @@ type DigitalEventItemProps = {
   canMoveUp?: boolean;
   hasTVPreferredFocus?: boolean;
   canMoveRight?: boolean;
+  continueWatching?: boolean;
   onFocus?: (...[]: any[]) => void;
 };
 
 const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
   (
-    { event, canMoveUp, hasTVPreferredFocus, canMoveRight = true, onFocus },
+    { event, canMoveUp, hasTVPreferredFocus, canMoveRight = true, onFocus, continueWatching },
     ref: any,
   ) => {
     const navigation = useNavigation();
@@ -42,8 +43,8 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
     const onPressHandler = () => {
       navMenuManager.hideNavMenu();
       navigation.navigate(
-        additionalRoutesWithoutNavMenuNavigation.eventDetais.navMenuScreenName,
-        { event },
+        additionalRoutesWithoutNavMenuNavigation.eventDetails.navMenuScreenName,
+        { event, continueWatching },
       );
     };
     return (
@@ -57,6 +58,7 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
           style={styles.imageContainer}
           onFocus={() => {
             ref?.current?.setDigitalEvent(event);
+            //ref?.current?.setShowContinueWatching(continueWatching)
             navMenuManager.setNavMenuAccessible();
             if (typeof onFocus === 'function') {
               onFocus();

--- a/src/components/EventListComponents/components/Preview.tsx
+++ b/src/components/EventListComponents/components/Preview.tsx
@@ -15,6 +15,7 @@ import { Colors } from '@themes/Styleguide';
 
 export type TPreviewRef = {
   setDigitalEvent?: (digitalEvent: TEventContainer) => void;
+  setShowContinueWatching?: (showContinueWatching: boolean) => void;
 };
 
 type TPreviewProps = {};
@@ -34,6 +35,7 @@ const Preview = forwardRef<TPreviewRef, TPreviewProps>((props, ref) => {
     }),
     [],
   );
+
   const eventGroupTitle: string = get(
     event,
     ['vs_event_details', 'tags', '0', 'attributes', 'title'],

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -60,7 +60,7 @@ export const SearchItemComponent: React.FC<TSearchItemComponentProps> = ({
   const touchableHandler = () => {
     navMenuManager.hideNavMenu();
     navigation.push(
-      additionalRoutesWithoutNavMenuNavigation.eventDetais.navMenuScreenName,
+      additionalRoutesWithoutNavMenuNavigation.eventDetails.navMenuScreenName,
       { event: item },
     );
   };

--- a/src/navigations/routes.tsx
+++ b/src/navigations/routes.tsx
@@ -92,7 +92,7 @@ export const routes: TRoutes = [
 ];
 
 export const additionalRoutesWithoutNavMenuNavigation = {
-  eventDetais: {
+  eventDetails: {
     navMenuScreenName: 'eventDetails',
     ScreenComponent: EventDetailsScreen,
     isDefault: false,

--- a/src/screens/EventDetailsScreen/index.tsx
+++ b/src/screens/EventDetailsScreen/index.tsx
@@ -27,18 +27,18 @@ import { useFocusEffect } from '@react-navigation/native';
 import { globalModalManager } from '@components/GlobalModal';
 import { ErrorModal } from '@components/GlobalModal/variants';
 
-type TEventDetalsScreenProps = StackScreenProps<
+type TEventDetailsScreenProps = StackScreenProps<
   { eventDetails: { event: TEventContainer } },
   'eventDetails'
 >;
 
-const EventDetailsScreen: React.FC<TEventDetalsScreenProps> = ({ route }) => {
+const EventDetailsScreen: React.FC<TEventDetailsScreenProps> = ({ route }) => {
   const [bMPlayerShowingData, setIsBMPlayerShowing] =
     useState<TBMPlayerShowingData | null>(null);
   const [bMPlayerError, setBMPlayerError] =
     useState<TBMPlayerErrorObject | null>(null);
   const isBMPlayerShowingRef = useRef<boolean>(false);
-  const { event } = route.params;
+  const { event, continueWatching } = route.params;
   const VirtualizedListRef = useRef<VirtualizedList<any>>(null);
   const eventDetailsScreenMounted = useRef<boolean>(false);
   const showPlayer = useCallback((playerItem: TBMPlayerShowingData) => {
@@ -92,6 +92,7 @@ const EventDetailsScreen: React.FC<TEventDetalsScreenProps> = ({ route }) => {
               key={item?.key || index}
               event={event}
               showPlayer={showPlayer}
+              continueWatching={continueWatching}
               isBMPlayerShowing={bMPlayerShowingData !== null}
               nextScreenText={item.nextSectionTitle}
             />
@@ -123,7 +124,7 @@ const EventDetailsScreen: React.FC<TEventDetalsScreenProps> = ({ route }) => {
               setBMPlayerError(null);
             });
           },
-          title: "Player's Error",
+          title: "Player Error",
           subtitle: `Something went wrong.\n${bMPlayerError.errCode}: ${
             bMPlayerError.errMessage
           }\n${bMPlayerError.url || ''}`,

--- a/src/screens/HomePageScreen/index.tsx
+++ b/src/screens/HomePageScreen/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '@configs/navMenuConfig';
 import { useMyList } from '@hooks/useMyList';
 import { useContinueWatchingList } from '@hooks/useContinueWatchingList';
+import { continueWatchingRailTitle } from '@configs/bitMovinPlayerConfig';
 
 type THomePageScreenProps = {};
 const HomePageScreen: React.FC<THomePageScreenProps> = () => {
@@ -51,6 +52,7 @@ const HomePageScreen: React.FC<THomePageScreenProps> = () => {
               hasTVPreferredFocus={isFirstRail && index === 0}
               canMoveRight={index !== section.data.length - 1}
               onFocus={scrollToRail}
+              continueWatching={section.title === continueWatchingRailTitle}
             />
           )}
         />


### PR DESCRIPTION
**What?**

Videos that have already been watched should in the event detail screen present the text "Continue watching" instead of "Watch now"

**Why?**

Users want to pick up where they left off, in almost every case.

**How?**

If we navigate from the "Continue watching" rail, we forward a true boolean prop from there. For other videos, I make a call to prismic. If the user is unsubscribed (or errors occur), the prismic call concludes silently. If subscribed, we fetch the necessary ids so that we can establish whether or not the video has been played.

Note that the data shown in the "Continue watching"-rail just fetches all "Continue Watching" videos. To actually identify a specific "Continue watching" video, we need the ids that we retrieve as described above. At least, that's the way the app works now.

**Testing?**

From "Continue Watching" rail, navigate to Event details screen and see that the "Watch now"-text is "Continue watching" instead of "Watch now".

Do the same from another rail (for a video that is not in the "Continue Watching" rail) and note that the "Watch now"-text is 
"Watch now"...and changes to "Continue watching" after the video has been watched.

**Extra info**

The new prismic call is actually the first part of what happens when we press the "Watch now" option. I tried to optimise by saving the result of this call, but it got a bit too complicated because of several other things that the call to get the performance video does. So I think that's best left for another time.

Closes #123 