### PR TITLE
remove subtitles option on event page as does not do anything

### DIFF
--- a/src/components/EventDetailsComponents/components/General.tsx
+++ b/src/components/EventDetailsComponents/components/General.tsx
@@ -345,13 +345,6 @@ const General: React.FC<Props> = ({
           onFocus: () => console.log('Add to my list focus'),
           Icon: AddToMyList,
         },
-        {
-          key: 'Audio&Subtitles',
-          text: 'Audio & Subtitles',
-          onPress: () => console.log('Audio & Subtitles press'),
-          onFocus: () => console.log('Audio & Subtitles focus'),
-          Icon: Subtitles,
-        },
       ],
     };
     if (typeOfList in buttonListCollection) {


### PR DESCRIPTION
#125  Event item - remove subtitles option on the event page as does not do anything