### PR TITLE
App starting screen: skip 'get started' for paired apps

### DIFF
--- a/src/screens/introScreen/index.tsx
+++ b/src/screens/introScreen/index.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { View, Image, ImageBackground, StyleSheet } from 'react-native';
+import { View, ImageBackground, StyleSheet } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { Colors, Images } from '@themes/Styleguide';
 import { scaleSize } from '@utils/scaleSize';
 import RohText from '@components/RohText';
-import { startLoginLoop } from '@services/store/auth/Slices';
+import {
+  startLoginLoop,
+  switchOffIntroScreen,
+} from '@services/store/auth/Slices';
 import TouchableHighlightWrapper from '@components/TouchableHighlightWrapper';
 import IntroStreamLogoSvg from '@assets/svg/IntroStreamLogo.svg';
 
@@ -13,6 +16,7 @@ type TIntroScreenProps = {};
 const IntroScreen: React.FC<TIntroScreenProps> = () => {
   const dispatch = useDispatch();
   const getStarted = () => {
+    dispatch(switchOffIntroScreen());
     dispatch(startLoginLoop());
   };
   return (

--- a/src/services/store/auth/Selectors.ts
+++ b/src/services/store/auth/Selectors.ts
@@ -16,3 +16,7 @@ export const subscribedModeSelector = (store: { [key: string]: any }) =>
 
 export const userEmailSelector = (store: { [key: string]: any }) =>
   store.auth.userEmail;
+
+export const deviceAuthenticatedInfoLoadedSelector = (store: {
+  [key: string]: any;
+}) => store.auth.isLoaded;

--- a/src/services/store/auth/Slices.ts
+++ b/src/services/store/auth/Slices.ts
@@ -3,6 +3,7 @@ import { createSlice } from '@reduxjs/toolkit';
 interface AuthState {
   isAuthenticated: boolean;
   isLoading: boolean;
+  isLoaded: boolean;
   devicePin: null | string;
   customerId: null | number;
   showIntroScreen: boolean;
@@ -14,6 +15,7 @@ interface AuthState {
 const initialState: AuthState = {
   isAuthenticated: false,
   isLoading: false,
+  isLoaded: false,
   devicePin: null,
   customerId: null,
   showIntroScreen: true,
@@ -45,14 +47,15 @@ const appSlice = createSlice({
       state.showIntroScreen = false;
       state.errorString = '';
       state.userEmail = payload.data.attributes.email;
+      state.isLoaded = true;
     },
     checkDeviceError: (state, { payload }) => {
       state.devicePin = payload?.detail || '';
-      state.showIntroScreen = false;
       if (payload.status !== 401) {
         state.errorString = `${payload.status} - ${payload?.title}`;
       }
       state.isLoading = false;
+      state.isLoaded = true;
     },
     clearAuthState: () => ({ ...initialState }),
     toggleSubscriptionMode: state => {


### PR DESCRIPTION
#166 App starting screen: skip 'get started' for paired apps